### PR TITLE
Quick fix to pink noise spectrum.

### DIFF
--- a/BRP_PACU.c
+++ b/BRP_PACU.c
@@ -46,7 +46,10 @@ volatile char run = 1;
 static guint timer_id = 0;
 // static guint BUF_SIZE = BUFSIZE;
 float b0, b1, b2, b3, b4, b5, b6, white;
-float scale_it = 0.98;
+float scale_it = 1.0f; // was 0.98, which is wrong (shifts the
+                       // poles to create a highpass. Let's hope
+                       // this wasn't a quick hack to work around
+                       // a numerical instability...
 float volume = 0.5;
 GMutex *thread_mutex;
 

--- a/BRP_PACU.c
+++ b/BRP_PACU.c
@@ -46,7 +46,6 @@ volatile char run = 1;
 static guint timer_id = 0;
 // static guint BUF_SIZE = BUFSIZE;
 float b0, b1, b2, b3, b4, b5, b6, white;
-float tmp_time = 0.0;
 float scale_it = 0.98;
 float volume = 0.5;
 GMutex *thread_mutex;
@@ -95,7 +94,6 @@ int Fill_Buffer(jack_nframes_t nframes, void *arg) {
                 b3 = (0.86650 * b3 + white * 0.3104856) * scale_it;
                 b4 = (0.55000 * b4 + white * 0.5329522) * scale_it;
                 b5 = (-0.7616 * b5 - white * 0.0168980) * scale_it;
-                tmp_time = tmp_time + 1.0 / 44100;
                 if (fill_it->pink_muted)
                     pink_noise[k] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 +
                                      (white * 0.5362) * scale_it) *

--- a/gui.c
+++ b/gui.c
@@ -1174,6 +1174,11 @@ gboolean create_gui(struct FFT_Frame *data, char *datadir) {
     datadir = gtkosx_application_get_resource_path();
 #endif
     sprintf(gtkbuilder_path, "%s/BRP_PACU.ui", datadir);
+    if (access(gtkbuilder_path, R_OK) != 0 ) {
+        fprintf(stderr, "Notice: system-wide UI file %s doesn't exist, assume we're running from the build environment and try './'",
+                gtkbuilder_path);
+        sprintf(gtkbuilder_path, "./BRP_PACU.ui");
+    }
     if (gtk_builder_add_from_file(builder, gtkbuilder_path, &error) == 0) {
         // gtk_builder_add_from_file throws error about the path
         message("Couldn't load builder file: %s", gtkbuilder_path, TRUE);


### PR DESCRIPTION
The fix was trivial, and it turns out that both the original BRP-PACU and Fons (of JAPA/jnoise) used the same textbook implementation). Only that BRP-PACU scaled the filter coefficients for some unknown reason, which created that highpass we're seeing.